### PR TITLE
Removed hardcoded version number 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,15 +48,15 @@ requirements:
     - nptyping <1.5.0,>=1.4.4
     - omegaconf <2.2.0,>=2.1.1
     - sentencepiece <0.2.0,>=0.1.95
-    - autogluon.core ==0.6.2
-    - autogluon.features ==0.6.2
-    - autogluon.common ==0.6.2
     - pytorch-metric-learning # <1.4.0,>=1.3.0
     - nlpaug <=1.1.10,>=1.1.10
     - nltk <4.0.0,>=3.4.5
     - openmim # <=0.2.1,>0.1.5
     - defusedxml <=0.7.1,>=0.7.1
     - albumentations <=1.2.0,>=1.1.0
+    - autogluon.core =={{ version }}
+    - autogluon.features =={{ version }}
+    - autogluon.common =={{ version }}
 
 test:
   imports:


### PR DESCRIPTION
The PR removes hardcoded autogluon version number from the dependencies and relaces it with `{{ version}}`. In this way, the recipe can support auto bot merge.