### PR TITLE
Changed pytorch to pytorch-gpu

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - evaluate <=0.3.0
     - accelerate <0.14,>=0.9
     - timm <0.7.0
-    - pytorch <1.13,>=1.9
+    - pytorch-gpu <1.13,>=1.9
     - torchvision <0.14.0
     - torchtext <0.14.0
     - fairscale <=0.4.6,>=0.4.5


### PR DESCRIPTION
This PR changes `pytorch` to `pytorch-gpu`

https://github.com/autogluon/autogluon/issues/612#issuecomment-1407229851