### PR TITLE
Update to v1.5.0

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,5 +1,3 @@
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,6 +7,6 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 python_min:
-- '3.9'
+- '3.10'
 target_platform:
 - linux-64

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @shchur @Innixma @prateekdesai04
+* @Innixma @prateekdesai04 @shchur

--- a/README.md
+++ b/README.md
@@ -106,12 +106,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -138,7 +138,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/autogluon.multimodal-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:
@@ -153,6 +153,5 @@ Feedstock Maintainers
 
 * [@Innixma](https://github.com/Innixma/)
 * [@prateekdesai04](https://github.com/prateekdesai04/)
-* [@suzhoum](https://github.com/suzhoum/)
-* [@tonyhoo](https://github.com/tonyhoo/)
+* [@shchur](https://github.com/shchur/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "autogluon.multimodal" %}
-{% set version = "1.4.0" %}
+{% set version = "1.5.0" %}
 
 # {% set autogluon_proc_type = "cpu" if cuda_compiler_version == "None" else "gpu" %}  # [linux64]
 # {% set autogluon_proc_type = "cpu" %}   # [not linux64]
@@ -10,12 +10,12 @@ package:
 
 source:
   url: https://github.com/autogluon/autogluon/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 42e4838bb95328cedb54a9d094072068d8ce1e610a1154f91190b3670011561b
+  sha256: 133ceb769cebce26255f379c129b58acacab2424a692b7ee81f02d78bbb228cb
 
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install ./multimodal -vv
-  number: 0 
+  number: 0
   script_env:
     - RELEASE=1
 
@@ -30,7 +30,7 @@ requirements:
     - pip
     - setuptools
   run:
-    - python >={{ python_min }},<3.13
+    - python >={{ python_min }},<3.14
     - numpy >=1.25.0,<2.4.0
     - scipy >=1.5.4,<1.17
     - pandas >=2.0.0,<2.4.0
@@ -38,10 +38,10 @@ requirements:
     - pillow >=10.0.1,<12
     - tqdm >=4.38,<5
     - boto3 >=1.10,<2
-    - pytorch >=2.2,<2.8
-    - torchvision >=0.16.0,<0.23.0
-    - lightning >=2.2,<2.8
-    - transformers >=4.38.0,<5
+    - pytorch >=2.6,<2.10
+    - torchvision >=0.21.0,<0.25.0
+    - lightning >=2.5.1,<2.6
+    - transformers >=4.51.0,<4.58
     - sentencepiece >=0.1.91,!=0.1.92
     - accelerate >=0.34.0,<2.0
     - requests >=2.30,<3


### PR DESCRIPTION
## Summary
- Update autogluon.multimodal to version 1.5.0
- Updated Python version constraint to <3.14 (from <3.13)
- Updated pytorch, torchvision, lightning, transformers version constraints

## Dependency Changes
- Python: `>=3.9,<3.13` → `>=3.10,<3.14`
- pytorch: `>=2.2,<2.8` → `>=2.6,<2.10`
- torchvision: `>=0.16.0,<0.23.0` → `>=0.21.0,<0.25.0`
- lightning: `>=2.2,<2.8` → `>=2.5.1,<2.6`
- transformers: `>=4.38.0,<5` → `>=4.51.0,<4.58`
